### PR TITLE
Fix all tests with go-bk removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ testdata
 
 # vim
 *.swp
+
+# installed bins
+bin/

--- a/internal/models/wallet.go
+++ b/internal/models/wallet.go
@@ -6,12 +6,12 @@ import (
 	"github.com/bsv-blockchain/go-bn/internal/util"
 	"github.com/bsv-blockchain/go-bn/models"
 	"github.com/bsv-blockchain/go-bt/v2"
-	"github.com/libsv/go-bk/wif"
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 // InternalDumpPrivateKey the true to form dumpprivkey response from the bitcoin node.
 type InternalDumpPrivateKey struct {
-	WIF *wif.WIF
+	PrivateKey *primitives.PrivateKey
 }
 
 // UnmarshalJSON unmarshal the response.
@@ -21,12 +21,12 @@ func (i *InternalDumpPrivateKey) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	w, err := wif.DecodeWIF(s)
+	pk, err := primitives.PrivateKeyFromWif(s)
 	if err != nil {
 		return err
 	}
 
-	i.WIF = w
+	i.PrivateKey = pk
 	return nil
 }
 

--- a/mocks/blockchain_client.go
+++ b/mocks/blockchain_client.go
@@ -5,10 +5,11 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	"github.com/bsv-blockchain/go-bc"
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/models"
-	"sync"
 )
 
 // Ensure, that BlockChainClientMock does implement bn.BlockChainClient.

--- a/mocks/control_client.go
+++ b/mocks/control_client.go
@@ -5,10 +5,11 @@ package mocks
 
 import (
 	"context"
-	"github.com/bsv-blockchain/go-bn"
-	"github.com/bsv-blockchain/go-bn/models"
 	"sync"
 	"time"
+
+	"github.com/bsv-blockchain/go-bn"
+	"github.com/bsv-blockchain/go-bn/models"
 )
 
 // Ensure, that ControlClientMock does implement bn.ControlClient.

--- a/mocks/mining_client.go
+++ b/mocks/mining_client.go
@@ -5,10 +5,11 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	"github.com/bsv-blockchain/go-bc"
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/models"
-	"sync"
 )
 
 // Ensure, that MiningClientMock does implement bn.MiningClient.

--- a/mocks/network_client.go
+++ b/mocks/network_client.go
@@ -5,10 +5,11 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/internal"
 	"github.com/bsv-blockchain/go-bn/models"
-	"sync"
 )
 
 // Ensure, that NetworkClientMock does implement bn.NetworkClient.

--- a/mocks/node_client.go
+++ b/mocks/node_client.go
@@ -5,14 +5,15 @@ package mocks
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	"github.com/bsv-blockchain/go-bc"
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/internal"
 	"github.com/bsv-blockchain/go-bn/models"
 	"github.com/bsv-blockchain/go-bt/v2"
-	"github.com/libsv/go-bk/wif"
-	"sync"
-	"time"
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 // Ensure, that NodeClientMock does implement bn.NodeClient.
@@ -130,7 +131,7 @@ var _ bn.NodeClient = &NodeClientMock{}
 //			DumpParamsFunc: func(ctx context.Context) ([]string, error) {
 //				panic("mock out the DumpParams method")
 //			},
-//			DumpPrivateKeyFunc: func(ctx context.Context, address string) (*wif.WIF, error) {
+//			DumpPrivateKeyFunc: func(ctx context.Context, address string) (*primitives.PrivateKey, error) {
 //				panic("mock out the DumpPrivateKey method")
 //			},
 //			DumpWalletFunc: func(ctx context.Context, dest string) (*models.DumpWallet, error) {
@@ -157,7 +158,7 @@ var _ bn.NodeClient = &NodeClientMock{}
 //			ImportMultiFunc: func(ctx context.Context, reqs []models.ImportMultiRequest, opts *models.OptsImportMulti) ([]*models.ImportMulti, error) {
 //				panic("mock out the ImportMulti method")
 //			},
-//			ImportPrivateKeyFunc: func(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error {
+//			ImportPrivateKeyFunc: func(ctx context.Context, w *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error {
 //				panic("mock out the ImportPrivateKey method")
 //			},
 //			ImportPrunedFundsFunc: func(ctx context.Context, tx *bt.Tx, txOutProof string) error {
@@ -340,7 +341,7 @@ var _ bn.NodeClient = &NodeClientMock{}
 //			SignMessageFunc: func(ctx context.Context, address string, message string) (string, error) {
 //				panic("mock out the SignMessage method")
 //			},
-//			SignMessageWithPrivKeyFunc: func(ctx context.Context, w *wif.WIF, msg string) (string, error) {
+//			SignMessageWithPrivKeyFunc: func(ctx context.Context, w *primitives.PrivateKey, msg string) (string, error) {
 //				panic("mock out the SignMessageWithPrivKey method")
 //			},
 //			SignRawTransactionFunc: func(ctx context.Context, tx *bt.Tx, opts *models.OptsSignRawTransaction) (*models.SignedRawTransaction, error) {
@@ -373,7 +374,7 @@ var _ bn.NodeClient = &NodeClientMock{}
 //			VerifyChainFunc: func(ctx context.Context) (bool, error) {
 //				panic("mock out the VerifyChain method")
 //			},
-//			VerifySignedMessageFunc: func(ctx context.Context, w *wif.WIF, signature string, message string) (bool, error) {
+//			VerifySignedMessageFunc: func(ctx context.Context, w *primitives.PrivateKey, signature string, message string) (bool, error) {
 //				panic("mock out the VerifySignedMessage method")
 //			},
 //			WalletInfoFunc: func(ctx context.Context) (*models.WalletInfo, error) {
@@ -507,7 +508,7 @@ type NodeClientMock struct {
 	DumpParamsFunc func(ctx context.Context) ([]string, error)
 
 	// DumpPrivateKeyFunc mocks the DumpPrivateKey method.
-	DumpPrivateKeyFunc func(ctx context.Context, address string) (*wif.WIF, error)
+	DumpPrivateKeyFunc func(ctx context.Context, address string) (*primitives.PrivateKey, error)
 
 	// DumpWalletFunc mocks the DumpWallet method.
 	DumpWalletFunc func(ctx context.Context, dest string) (*models.DumpWallet, error)
@@ -534,7 +535,7 @@ type NodeClientMock struct {
 	ImportMultiFunc func(ctx context.Context, reqs []models.ImportMultiRequest, opts *models.OptsImportMulti) ([]*models.ImportMulti, error)
 
 	// ImportPrivateKeyFunc mocks the ImportPrivateKey method.
-	ImportPrivateKeyFunc func(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error
+	ImportPrivateKeyFunc func(ctx context.Context, w *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error
 
 	// ImportPrunedFundsFunc mocks the ImportPrunedFunds method.
 	ImportPrunedFundsFunc func(ctx context.Context, tx *bt.Tx, txOutProof string) error
@@ -720,7 +721,7 @@ type NodeClientMock struct {
 	SignMessageFunc func(ctx context.Context, address string, message string) (string, error)
 
 	// SignMessageWithPrivKeyFunc mocks the SignMessageWithPrivKey method.
-	SignMessageWithPrivKeyFunc func(ctx context.Context, w *wif.WIF, msg string) (string, error)
+	SignMessageWithPrivKeyFunc func(ctx context.Context, w *primitives.PrivateKey, msg string) (string, error)
 
 	// SignRawTransactionFunc mocks the SignRawTransaction method.
 	SignRawTransactionFunc func(ctx context.Context, tx *bt.Tx, opts *models.OptsSignRawTransaction) (*models.SignedRawTransaction, error)
@@ -753,7 +754,7 @@ type NodeClientMock struct {
 	VerifyChainFunc func(ctx context.Context) (bool, error)
 
 	// VerifySignedMessageFunc mocks the VerifySignedMessage method.
-	VerifySignedMessageFunc func(ctx context.Context, w *wif.WIF, signature string, message string) (bool, error)
+	VerifySignedMessageFunc func(ctx context.Context, w *primitives.PrivateKey, signature string, message string) (bool, error)
 
 	// WalletInfoFunc mocks the WalletInfo method.
 	WalletInfoFunc func(ctx context.Context) (*models.WalletInfo, error)
@@ -1095,8 +1096,8 @@ type NodeClientMock struct {
 		ImportPrivateKey []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// W is the w argument value.
-			W *wif.WIF
+			// Pis the w argument value.
+			P *primitives.PrivateKey
 			// Opts is the opts argument value.
 			Opts *models.OptsImportPrivateKey
 		}
@@ -1545,8 +1546,8 @@ type NodeClientMock struct {
 		SignMessageWithPrivKey []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// W is the w argument value.
-			W *wif.WIF
+			// Pis the w argument value.
+			P *primitives.PrivateKey
 			// Msg is the msg argument value.
 			Msg string
 		}
@@ -1622,8 +1623,8 @@ type NodeClientMock struct {
 		VerifySignedMessage []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// W is the w argument value.
-			W *wif.WIF
+			// Pis the w argument value.
+			P *primitives.PrivateKey
 			// Signature is the signature argument value.
 			Signature string
 			// Message is the message argument value.
@@ -3061,7 +3062,7 @@ func (mock *NodeClientMock) DumpParamsCalls() []struct {
 }
 
 // DumpPrivateKey calls DumpPrivateKeyFunc.
-func (mock *NodeClientMock) DumpPrivateKey(ctx context.Context, address string) (*wif.WIF, error) {
+func (mock *NodeClientMock) DumpPrivateKey(ctx context.Context, address string) (*primitives.PrivateKey, error) {
 	if mock.DumpPrivateKeyFunc == nil {
 		panic("NodeClientMock.DumpPrivateKeyFunc: method is nil but NodeClient.DumpPrivateKey was just called")
 	}
@@ -3405,23 +3406,23 @@ func (mock *NodeClientMock) ImportMultiCalls() []struct {
 }
 
 // ImportPrivateKey calls ImportPrivateKeyFunc.
-func (mock *NodeClientMock) ImportPrivateKey(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error {
+func (mock *NodeClientMock) ImportPrivateKey(ctx context.Context, p *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error {
 	if mock.ImportPrivateKeyFunc == nil {
 		panic("NodeClientMock.ImportPrivateKeyFunc: method is nil but NodeClient.ImportPrivateKey was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
-		W    *wif.WIF
+		P    *primitives.PrivateKey
 		Opts *models.OptsImportPrivateKey
 	}{
 		Ctx:  ctx,
-		W:    w,
+		P:    p,
 		Opts: opts,
 	}
 	mock.lockImportPrivateKey.Lock()
 	mock.calls.ImportPrivateKey = append(mock.calls.ImportPrivateKey, callInfo)
 	mock.lockImportPrivateKey.Unlock()
-	return mock.ImportPrivateKeyFunc(ctx, w, opts)
+	return mock.ImportPrivateKeyFunc(ctx, p, opts)
 }
 
 // ImportPrivateKeyCalls gets all the calls that were made to ImportPrivateKey.
@@ -3430,12 +3431,12 @@ func (mock *NodeClientMock) ImportPrivateKey(ctx context.Context, w *wif.WIF, op
 //	len(mockedNodeClient.ImportPrivateKeyCalls())
 func (mock *NodeClientMock) ImportPrivateKeyCalls() []struct {
 	Ctx  context.Context
-	W    *wif.WIF
+	P    *primitives.PrivateKey
 	Opts *models.OptsImportPrivateKey
 } {
 	var calls []struct {
 		Ctx  context.Context
-		W    *wif.WIF
+		P    *primitives.PrivateKey
 		Opts *models.OptsImportPrivateKey
 	}
 	mock.lockImportPrivateKey.RLock()
@@ -5651,23 +5652,23 @@ func (mock *NodeClientMock) SignMessageCalls() []struct {
 }
 
 // SignMessageWithPrivKey calls SignMessageWithPrivKeyFunc.
-func (mock *NodeClientMock) SignMessageWithPrivKey(ctx context.Context, w *wif.WIF, msg string) (string, error) {
+func (mock *NodeClientMock) SignMessageWithPrivKey(ctx context.Context, p *primitives.PrivateKey, msg string) (string, error) {
 	if mock.SignMessageWithPrivKeyFunc == nil {
 		panic("NodeClientMock.SignMessageWithPrivKeyFunc: method is nil but NodeClient.SignMessageWithPrivKey was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
-		W   *wif.WIF
+		P   *primitives.PrivateKey
 		Msg string
 	}{
 		Ctx: ctx,
-		W:   w,
+		P:   p,
 		Msg: msg,
 	}
 	mock.lockSignMessageWithPrivKey.Lock()
 	mock.calls.SignMessageWithPrivKey = append(mock.calls.SignMessageWithPrivKey, callInfo)
 	mock.lockSignMessageWithPrivKey.Unlock()
-	return mock.SignMessageWithPrivKeyFunc(ctx, w, msg)
+	return mock.SignMessageWithPrivKeyFunc(ctx, p, msg)
 }
 
 // SignMessageWithPrivKeyCalls gets all the calls that were made to SignMessageWithPrivKey.
@@ -5676,12 +5677,12 @@ func (mock *NodeClientMock) SignMessageWithPrivKey(ctx context.Context, w *wif.W
 //	len(mockedNodeClient.SignMessageWithPrivKeyCalls())
 func (mock *NodeClientMock) SignMessageWithPrivKeyCalls() []struct {
 	Ctx context.Context
-	W   *wif.WIF
+	P   *primitives.PrivateKey
 	Msg string
 } {
 	var calls []struct {
 		Ctx context.Context
-		W   *wif.WIF
+		P   *primitives.PrivateKey
 		Msg string
 	}
 	mock.lockSignMessageWithPrivKey.RLock()
@@ -6047,25 +6048,25 @@ func (mock *NodeClientMock) VerifyChainCalls() []struct {
 }
 
 // VerifySignedMessage calls VerifySignedMessageFunc.
-func (mock *NodeClientMock) VerifySignedMessage(ctx context.Context, w *wif.WIF, signature string, message string) (bool, error) {
+func (mock *NodeClientMock) VerifySignedMessage(ctx context.Context, p *primitives.PrivateKey, signature string, message string) (bool, error) {
 	if mock.VerifySignedMessageFunc == nil {
 		panic("NodeClientMock.VerifySignedMessageFunc: method is nil but NodeClient.VerifySignedMessage was just called")
 	}
 	callInfo := struct {
 		Ctx       context.Context
-		W         *wif.WIF
+		P         *primitives.PrivateKey
 		Signature string
 		Message   string
 	}{
 		Ctx:       ctx,
-		W:         w,
+		P:         p,
 		Signature: signature,
 		Message:   message,
 	}
 	mock.lockVerifySignedMessage.Lock()
 	mock.calls.VerifySignedMessage = append(mock.calls.VerifySignedMessage, callInfo)
 	mock.lockVerifySignedMessage.Unlock()
-	return mock.VerifySignedMessageFunc(ctx, w, signature, message)
+	return mock.VerifySignedMessageFunc(ctx, p, signature, message)
 }
 
 // VerifySignedMessageCalls gets all the calls that were made to VerifySignedMessage.
@@ -6074,13 +6075,13 @@ func (mock *NodeClientMock) VerifySignedMessage(ctx context.Context, w *wif.WIF,
 //	len(mockedNodeClient.VerifySignedMessageCalls())
 func (mock *NodeClientMock) VerifySignedMessageCalls() []struct {
 	Ctx       context.Context
-	W         *wif.WIF
+	P         *primitives.PrivateKey
 	Signature string
 	Message   string
 } {
 	var calls []struct {
 		Ctx       context.Context
-		W         *wif.WIF
+		P         *primitives.PrivateKey
 		Signature string
 		Message   string
 	}

--- a/mocks/node_client.go
+++ b/mocks/node_client.go
@@ -1096,7 +1096,7 @@ type NodeClientMock struct {
 		ImportPrivateKey []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Pis the w argument value.
+			// P is the p argument value.
 			P *primitives.PrivateKey
 			// Opts is the opts argument value.
 			Opts *models.OptsImportPrivateKey

--- a/mocks/transaction_client.go
+++ b/mocks/transaction_client.go
@@ -5,10 +5,11 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/models"
 	"github.com/bsv-blockchain/go-bt/v2"
-	"sync"
 )
 
 // Ensure, that TransactionClientMock does implement bn.TransactionClient.

--- a/mocks/util_client.go
+++ b/mocks/util_client.go
@@ -5,10 +5,11 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/models"
-	"github.com/libsv/go-bk/wif"
-	"sync"
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 // Ensure, that UtilClientMock does implement bn.UtilClient.
@@ -27,13 +28,13 @@ var _ bn.UtilClient = &UtilClientMock{}
 //			CreateMultiSigFunc: func(ctx context.Context, n int, keys ...string) (*models.MultiSig, error) {
 //				panic("mock out the CreateMultiSig method")
 //			},
-//			SignMessageWithPrivKeyFunc: func(ctx context.Context, w *wif.WIF, msg string) (string, error) {
+//			SignMessageWithPrivKeyFunc: func(ctx context.Context, p *primitives.PrivateKey, msg string) (string, error) {
 //				panic("mock out the SignMessageWithPrivKey method")
 //			},
 //			ValidateAddressFunc: func(ctx context.Context, address string) (*models.ValidateAddress, error) {
 //				panic("mock out the ValidateAddress method")
 //			},
-//			VerifySignedMessageFunc: func(ctx context.Context, w *wif.WIF, signature string, message string) (bool, error) {
+//			VerifySignedMessageFunc: func(ctx context.Context, p *primitives.PrivateKey, signature string, message string) (bool, error) {
 //				panic("mock out the VerifySignedMessage method")
 //			},
 //		}
@@ -50,13 +51,13 @@ type UtilClientMock struct {
 	CreateMultiSigFunc func(ctx context.Context, n int, keys ...string) (*models.MultiSig, error)
 
 	// SignMessageWithPrivKeyFunc mocks the SignMessageWithPrivKey method.
-	SignMessageWithPrivKeyFunc func(ctx context.Context, w *wif.WIF, msg string) (string, error)
+	SignMessageWithPrivKeyFunc func(ctx context.Context, p *primitives.PrivateKey, msg string) (string, error)
 
 	// ValidateAddressFunc mocks the ValidateAddress method.
 	ValidateAddressFunc func(ctx context.Context, address string) (*models.ValidateAddress, error)
 
 	// VerifySignedMessageFunc mocks the VerifySignedMessage method.
-	VerifySignedMessageFunc func(ctx context.Context, w *wif.WIF, signature string, message string) (bool, error)
+	VerifySignedMessageFunc func(ctx context.Context, p *primitives.PrivateKey, signature string, message string) (bool, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -78,8 +79,8 @@ type UtilClientMock struct {
 		SignMessageWithPrivKey []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// W is the w argument value.
-			W *wif.WIF
+			// P is the p argument value.
+			P *primitives.PrivateKey
 			// Msg is the msg argument value.
 			Msg string
 		}
@@ -94,8 +95,8 @@ type UtilClientMock struct {
 		VerifySignedMessage []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// W is the w argument value.
-			W *wif.WIF
+			// P is the p argument value.
+			P *primitives.PrivateKey
 			// Signature is the signature argument value.
 			Signature string
 			// Message is the message argument value.
@@ -182,23 +183,23 @@ func (mock *UtilClientMock) CreateMultiSigCalls() []struct {
 }
 
 // SignMessageWithPrivKey calls SignMessageWithPrivKeyFunc.
-func (mock *UtilClientMock) SignMessageWithPrivKey(ctx context.Context, w *wif.WIF, msg string) (string, error) {
+func (mock *UtilClientMock) SignMessageWithPrivKey(ctx context.Context, p *primitives.PrivateKey, msg string) (string, error) {
 	if mock.SignMessageWithPrivKeyFunc == nil {
 		panic("UtilClientMock.SignMessageWithPrivKeyFunc: method is nil but UtilClient.SignMessageWithPrivKey was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
-		W   *wif.WIF
+		P   *primitives.PrivateKey
 		Msg string
 	}{
 		Ctx: ctx,
-		W:   w,
+		P:   p,
 		Msg: msg,
 	}
 	mock.lockSignMessageWithPrivKey.Lock()
 	mock.calls.SignMessageWithPrivKey = append(mock.calls.SignMessageWithPrivKey, callInfo)
 	mock.lockSignMessageWithPrivKey.Unlock()
-	return mock.SignMessageWithPrivKeyFunc(ctx, w, msg)
+	return mock.SignMessageWithPrivKeyFunc(ctx, p, msg)
 }
 
 // SignMessageWithPrivKeyCalls gets all the calls that were made to SignMessageWithPrivKey.
@@ -207,12 +208,12 @@ func (mock *UtilClientMock) SignMessageWithPrivKey(ctx context.Context, w *wif.W
 //	len(mockedUtilClient.SignMessageWithPrivKeyCalls())
 func (mock *UtilClientMock) SignMessageWithPrivKeyCalls() []struct {
 	Ctx context.Context
-	W   *wif.WIF
+	P   *primitives.PrivateKey
 	Msg string
 } {
 	var calls []struct {
 		Ctx context.Context
-		W   *wif.WIF
+		P   *primitives.PrivateKey
 		Msg string
 	}
 	mock.lockSignMessageWithPrivKey.RLock()
@@ -258,25 +259,25 @@ func (mock *UtilClientMock) ValidateAddressCalls() []struct {
 }
 
 // VerifySignedMessage calls VerifySignedMessageFunc.
-func (mock *UtilClientMock) VerifySignedMessage(ctx context.Context, w *wif.WIF, signature string, message string) (bool, error) {
+func (mock *UtilClientMock) VerifySignedMessage(ctx context.Context, p *primitives.PrivateKey, signature string, message string) (bool, error) {
 	if mock.VerifySignedMessageFunc == nil {
 		panic("UtilClientMock.VerifySignedMessageFunc: method is nil but UtilClient.VerifySignedMessage was just called")
 	}
 	callInfo := struct {
 		Ctx       context.Context
-		W         *wif.WIF
+		P         *primitives.PrivateKey
 		Signature string
 		Message   string
 	}{
 		Ctx:       ctx,
-		W:         w,
+		P:         p,
 		Signature: signature,
 		Message:   message,
 	}
 	mock.lockVerifySignedMessage.Lock()
 	mock.calls.VerifySignedMessage = append(mock.calls.VerifySignedMessage, callInfo)
 	mock.lockVerifySignedMessage.Unlock()
-	return mock.VerifySignedMessageFunc(ctx, w, signature, message)
+	return mock.VerifySignedMessageFunc(ctx, p, signature, message)
 }
 
 // VerifySignedMessageCalls gets all the calls that were made to VerifySignedMessage.
@@ -285,13 +286,13 @@ func (mock *UtilClientMock) VerifySignedMessage(ctx context.Context, w *wif.WIF,
 //	len(mockedUtilClient.VerifySignedMessageCalls())
 func (mock *UtilClientMock) VerifySignedMessageCalls() []struct {
 	Ctx       context.Context
-	W         *wif.WIF
+	P         *primitives.PrivateKey
 	Signature string
 	Message   string
 } {
 	var calls []struct {
 		Ctx       context.Context
-		W         *wif.WIF
+		P         *primitives.PrivateKey
 		Signature string
 		Message   string
 	}

--- a/mocks/wallet_client.go
+++ b/mocks/wallet_client.go
@@ -5,11 +5,12 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/models"
 	"github.com/bsv-blockchain/go-bt/v2"
-	"github.com/libsv/go-bk/wif"
-	"sync"
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 // Ensure, that WalletClientMock does implement bn.WalletClient.
@@ -180,7 +181,7 @@ type WalletClientMock struct {
 	BalanceFunc func(ctx context.Context, opts *models.OptsBalance) (uint64, error)
 
 	// DumpPrivateKeyFunc mocks the DumpPrivateKey method.
-	DumpPrivateKeyFunc func(ctx context.Context, address string) (*wif.WIF, error)
+	DumpPrivateKeyFunc func(ctx context.Context, address string) (*primitives.PrivateKey, error)
 
 	// DumpWalletFunc mocks the DumpWallet method.
 	DumpWalletFunc func(ctx context.Context, dest string) (*models.DumpWallet, error)
@@ -195,7 +196,7 @@ type WalletClientMock struct {
 	ImportMultiFunc func(ctx context.Context, reqs []models.ImportMultiRequest, opts *models.OptsImportMulti) ([]*models.ImportMulti, error)
 
 	// ImportPrivateKeyFunc mocks the ImportPrivateKey method.
-	ImportPrivateKeyFunc func(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error
+	ImportPrivateKeyFunc func(ctx context.Context, w *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error
 
 	// ImportPrunedFundsFunc mocks the ImportPrunedFunds method.
 	ImportPrunedFundsFunc func(ctx context.Context, tx *bt.Tx, txOutProof string) error
@@ -384,7 +385,7 @@ type WalletClientMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// W is the w argument value.
-			W *wif.WIF
+			P *primitives.PrivateKey
 			// Opts is the opts argument value.
 			Opts *models.OptsImportPrivateKey
 		}
@@ -923,7 +924,7 @@ func (mock *WalletClientMock) BalanceCalls() []struct {
 }
 
 // DumpPrivateKey calls DumpPrivateKeyFunc.
-func (mock *WalletClientMock) DumpPrivateKey(ctx context.Context, address string) (*wif.WIF, error) {
+func (mock *WalletClientMock) DumpPrivateKey(ctx context.Context, address string) (*primitives.PrivateKey, error) {
 	if mock.DumpPrivateKeyFunc == nil {
 		panic("WalletClientMock.DumpPrivateKeyFunc: method is nil but WalletClient.DumpPrivateKey was just called")
 	}
@@ -1111,23 +1112,23 @@ func (mock *WalletClientMock) ImportMultiCalls() []struct {
 }
 
 // ImportPrivateKey calls ImportPrivateKeyFunc.
-func (mock *WalletClientMock) ImportPrivateKey(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error {
+func (mock *WalletClientMock) ImportPrivateKey(ctx context.Context, p *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error {
 	if mock.ImportPrivateKeyFunc == nil {
 		panic("WalletClientMock.ImportPrivateKeyFunc: method is nil but WalletClient.ImportPrivateKey was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
-		W    *wif.WIF
+		P    *primitives.PrivateKey
 		Opts *models.OptsImportPrivateKey
 	}{
 		Ctx:  ctx,
-		W:    w,
+		P:    p,
 		Opts: opts,
 	}
 	mock.lockImportPrivateKey.Lock()
 	mock.calls.ImportPrivateKey = append(mock.calls.ImportPrivateKey, callInfo)
 	mock.lockImportPrivateKey.Unlock()
-	return mock.ImportPrivateKeyFunc(ctx, w, opts)
+	return mock.ImportPrivateKeyFunc(ctx, p, opts)
 }
 
 // ImportPrivateKeyCalls gets all the calls that were made to ImportPrivateKey.
@@ -1136,12 +1137,12 @@ func (mock *WalletClientMock) ImportPrivateKey(ctx context.Context, w *wif.WIF, 
 //	len(mockedWalletClient.ImportPrivateKeyCalls())
 func (mock *WalletClientMock) ImportPrivateKeyCalls() []struct {
 	Ctx  context.Context
-	W    *wif.WIF
+	P    *primitives.PrivateKey
 	Opts *models.OptsImportPrivateKey
 } {
 	var calls []struct {
 		Ctx  context.Context
-		W    *wif.WIF
+		P    *primitives.PrivateKey
 		Opts *models.OptsImportPrivateKey
 	}
 	mock.lockImportPrivateKey.RLock()

--- a/mocks/zmq4_mock.go
+++ b/mocks/zmq4_mock.go
@@ -4,9 +4,10 @@
 package mocks
 
 import (
-	"github.com/go-zeromq/zmq4"
 	"net"
 	"sync"
+
+	"github.com/go-zeromq/zmq4"
 )
 
 // Ensure, that SocketMock does implement zmq4.Socket.

--- a/wallet.go
+++ b/wallet.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bsv-blockchain/go-bn/internal/util"
 	"github.com/bsv-blockchain/go-bn/models"
 	"github.com/bsv-blockchain/go-bt/v2"
-	"github.com/libsv/go-bk/wif"
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 // WalletClient interfaces interaction with the wallet sub commands on a bitcoin node.
@@ -15,7 +15,7 @@ type WalletClient interface {
 	AbandonTransaction(ctx context.Context, txID string) error
 	AddMultiSigAddress(ctx context.Context, n int, keys ...string) (string, error)
 	BackupWallet(ctx context.Context, dest string) error
-	DumpPrivateKey(ctx context.Context, address string) (*wif.WIF, error)
+	DumpPrivateKey(ctx context.Context, address string) (*primitives.PrivateKey, error)
 	DumpWallet(ctx context.Context, dest string) (*models.DumpWallet, error)
 	Account(ctx context.Context, address string) (string, error)
 	AccountAddress(ctx context.Context, account string) (string, error)
@@ -30,7 +30,7 @@ type WalletClient interface {
 	WalletInfo(ctx context.Context) (*models.WalletInfo, error)
 	ImportMulti(ctx context.Context, reqs []models.ImportMultiRequest,
 		opts *models.OptsImportMulti) ([]*models.ImportMulti, error)
-	ImportPrivateKey(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error
+	ImportPrivateKey(ctx context.Context, pk *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error
 	ImportPrunedFunds(ctx context.Context, tx *bt.Tx, txOutProof string) error
 	ImportPublicKey(ctx context.Context, publicKey string, opts *models.OptsImportPublicKey) error
 	ImportWallet(ctx context.Context, filename string) error
@@ -80,9 +80,9 @@ func (c *client) BackupWallet(ctx context.Context, dest string) error {
 }
 
 // DumpPrivateKey retrieves the private key for the given address in WIF format.
-func (c *client) DumpPrivateKey(ctx context.Context, address string) (*wif.WIF, error) {
+func (c *client) DumpPrivateKey(ctx context.Context, address string) (*primitives.PrivateKey, error) {
 	var resp imodels.InternalDumpPrivateKey
-	return resp.WIF, c.rpc.Do(ctx, "dumpprivkey", &resp, address)
+	return resp.PrivateKey, c.rpc.Do(ctx, "dumpprivkey", &resp, address)
 }
 
 // DumpWallet dumps the wallet to the specified destination file.
@@ -178,8 +178,8 @@ func (c *client) ImportPublicKey(ctx context.Context, publicKey string, opts *mo
 }
 
 // ImportPrivateKey imports a private key (WIF) into the wallet, optionally filtered by the provided options.
-func (c *client) ImportPrivateKey(ctx context.Context, w *wif.WIF, opts *models.OptsImportPrivateKey) error {
-	return c.rpc.Do(ctx, "importprivkey", nil, c.argsFor(opts, w.String())...)
+func (c *client) ImportPrivateKey(ctx context.Context, pk *primitives.PrivateKey, opts *models.OptsImportPrivateKey) error {
+	return c.rpc.Do(ctx, "importprivkey", nil, c.argsFor(opts, pk.Wif())...)
 }
 
 // ImportWallet imports a wallet from a file.

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -5,13 +5,14 @@ import (
 	"net/http"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bn"
 	"github.com/bsv-blockchain/go-bn/internal/config"
 	"github.com/bsv-blockchain/go-bn/internal/mocks"
 	"github.com/bsv-blockchain/go-bn/internal/service"
 	"github.com/bsv-blockchain/go-bn/models"
 	"github.com/bsv-blockchain/go-bn/testing/util"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -203,7 +204,7 @@ func TestWalletClientDumpPrivateKey(t *testing.T) {
 	tests := map[string]struct {
 		testFile   string
 		address    string
-		expWif     *wif.WIF
+		expPk      *primitives.PrivateKey
 		expRequest models.Request
 		expErr     error
 	}{
@@ -216,8 +217,8 @@ func TestWalletClientDumpPrivateKey(t *testing.T) {
 				Method:  "dumpprivkey",
 				Params:  []interface{}{"mzcEDt2d7QwHazAwD11WWSn8eSCb4gtpSY"},
 			},
-			expWif: func() *wif.WIF {
-				wifKey, err := wif.DecodeWIF("cW9n4pgq9MqqGD8Ux5cwpgJAJ1VzPvZgskbCEmK1QmWUicejRFQn")
+			expPk: func() *primitives.PrivateKey {
+				wifKey, err := primitives.PrivateKeyFromWif("cW9n4pgq9MqqGD8Ux5cwpgJAJ1VzPvZgskbCEmK1QmWUicejRFQn")
 				assert.NoError(t, err)
 				return wifKey
 			}(),
@@ -252,7 +253,7 @@ func TestWalletClientDumpPrivateKey(t *testing.T) {
 				assert.EqualError(t, err, test.expErr.Error())
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, test.expWif, wifKey)
+				assert.Equal(t, test.expPk, wifKey)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request introduces a significant refactor to replace the usage of the `wif.WIF` type with `primitives.PrivateKey` across various files. The changes improve type consistency and simplify the codebase by consolidating private key handling under the `primitives` package. Additionally, minor import order adjustments were made to improve readability.

### Refactor: Replace `wif.WIF` with `primitives.PrivateKey`

* [`internal/models/wallet.go`](diffhunk://#diff-627e2938bee1b64b39b4176d460a5adc9211aa2503803c716270e7fca7ba2993L9-R14): Replaced the `WIF` field in the `InternalDumpPrivateKey` struct with `PrivateKey` and updated the `UnmarshalJSON` method to use `primitives.PrivateKeyFromWif` instead of `wif.DecodeWIF`. [[1]](diffhunk://#diff-627e2938bee1b64b39b4176d460a5adc9211aa2503803c716270e7fca7ba2993L9-R14) [[2]](diffhunk://#diff-627e2938bee1b64b39b4176d460a5adc9211aa2503803c716270e7fca7ba2993L24-R29)
* [`mocks/node_client.go`](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aR8-R16): Updated mock methods and fields to use `primitives.PrivateKey` instead of `wif.WIF` for private key-related functionality, including `DumpPrivateKeyFunc`, `ImportPrivateKeyFunc`, `SignMessageWithPrivKeyFunc`, and `VerifySignedMessageFunc`. [[1]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aR8-R16) [[2]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL133-R134) [[3]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL160-R161) [[4]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL343-R344) [[5]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL376-R377) [[6]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL510-R511) [[7]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL537-R538) [[8]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL723-R724) [[9]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL756-R757) [[10]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL1098-R1100) [[11]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL1548-R1550) [[12]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL1625-R1627) [[13]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL3064-R3065) [[14]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL3408-R3425) [[15]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL3433-R3439) [[16]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL5654-R5671) [[17]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL5679-R5685) [[18]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL6050-R6069) [[19]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aL6077-R6084)
* [`mocks/util_client.go`](diffhunk://#diff-d16d728faf57c40cf617ce2f6c6c102038d8e698c777b1aeea676b0b233c0f71R8-R12): Updated mock methods to use `primitives.PrivateKey` for signing and verifying messages, replacing `wif.WIF`. [[1]](diffhunk://#diff-d16d728faf57c40cf617ce2f6c6c102038d8e698c777b1aeea676b0b233c0f71R8-R12) [[2]](diffhunk://#diff-d16d728faf57c40cf617ce2f6c6c102038d8e698c777b1aeea676b0b233c0f71L30-R37) [[3]](diffhunk://#diff-d16d728faf57c40cf617ce2f6c6c102038d8e698c777b1aeea676b0b233c0f71L53-R60)

### Code Quality: Import Order Adjustments

* Adjusted import order in several mock files (`blockchain_client.go`, `control_client.go`, `mining_client.go`, `network_client.go`, `transaction_client.go`, `util_client.go`) for better readability and organization. [[1]](diffhunk://#diff-c5ae121b5246003760b30600f0b29682224cc5118c145724a90f604f4fdd965fR8-L11) [[2]](diffhunk://#diff-c9a0ba0111031de6cef27e0998e8def882c433f7062fbc4812982f78bb9d4d18L8-R12) [[3]](diffhunk://#diff-f75c52bd6ca5f250db276ea77f2f8d9cb5f17d7aafbadfbbb3c29beff9ceaf70R8-L11) [[4]](diffhunk://#diff-7e66d9009258693700b06e19e036e73ffc4383fd1db2f07dc16d463b53909e93R8-L11) [[5]](diffhunk://#diff-52e14cc2e5e7cca8b1be615d668e382c6f6d61ae397056a75ac421e01584d160R8-L11) [[6]](diffhunk://#diff-d16d728faf57c40cf617ce2f6c6c102038d8e698c777b1aeea676b0b233c0f71R8-R12)
