### PR TITLE
Expose more internal structs or usage in other libs

### DIFF
--- a/models/tx.go
+++ b/models/tx.go
@@ -249,22 +249,31 @@ type SendRawTransactionsResponse struct {
 	} `json:"unconfirmed"`
 }
 
-// AddToConsensusBlacklistResponse response
-type AddToConsensusBlacklistResponse struct {
-	NotProcessed []struct {
-		TxOut struct {
-			TxId string `json:"txId"`
-			Vout int    `json:"vout"`
-		} `json:"txOut"`
-		Reason string `json:"reason"`
-	} `json:"notProcessed"`
+// AddToConsensusBlacklistNotProcessed represents a not processed transaction output or confiscation transaction
+type AddToConsensusBlacklistNotProcessed []struct {
+	TxOut struct {
+		TxId string `json:"txId"`
+		Vout int    `json:"vout"`
+	}
+	Reason string `json:"reason"`
 }
 
+// AddToConsensusBlacklistResponse response
+type AddToConsensusBlacklistResponse struct {
+	AddToConsensusBlacklistNotProcessed `json:"notProcessed"`
+}
+
+type WhitelistConfiscationTransaction struct {
+	TxId string `json:"txId"`
+}
+
+// AddToConfiscationTransactionWhitelistNotProcessed represents a not processed confiscation transaction
+type AddToConfiscationTransactionWhitelistNotProcessed []struct {
+	WhitelistConfiscationTransaction `json:"confiscationTx"`
+	Reason                           string `json:"reason"`
+}
+
+// AddToConfiscationTransactionWhitelistResponse represents the response for adding confiscation transactions to the whitelist
 type AddToConfiscationTransactionWhitelistResponse struct {
-	NotProcessed []struct {
-		ConfiscationTransaction struct {
-			TxId string `json:"txId"`
-		} `json:"confiscationTx"`
-		Reason string `json:"reason"`
-	} `json:"notProcessed"`
+	AddToConfiscationTransactionWhitelistNotProcessed `json:"notProcessed"`
 }


### PR DESCRIPTION
This pull request refactors the response structures in `models/tx.go` to improve code readability and maintainability by introducing new type definitions for nested structures. The changes primarily focus on separating and reusing components within the `AddToConsensusBlacklistResponse` and `AddToConfiscationTransactionWhitelistResponse` types.

### Refactoring of response structures:

* Introduced `AddToConsensusBlacklistNotProcessed` type to represent a not processed transaction output or confiscation transaction, and updated `AddToConsensusBlacklistResponse` to use this new type. (`[models/tx.goL252-R278](diffhunk://#diff-6d5301c97541b896843d5363919d90686ed3489ab0ced2d2977848ff6daafb74L252-R278)`)
* Introduced `WhitelistConfiscationTransaction` type to encapsulate confiscation transaction details and `AddToConfiscationTransactionWhitelistNotProcessed` type for not processed confiscation transactions, updating `AddToConfiscationTransactionWhitelistResponse` accordingly. (`[models/tx.goL252-R278](diffhunk://#diff-6d5301c97541b896843d5363919d90686ed3489ab0ced2d2977848ff6daafb74L252-R278)`)